### PR TITLE
Use comodity name string if metadata is not defined

### DIFF
--- a/src/fava_portfolio_returns/api/portfolio.py
+++ b/src/fava_portfolio_returns/api/portfolio.py
@@ -27,7 +27,7 @@ def portfolio_allocation(
 ):
     market_values: dict[tuple, Decimal] = defaultdict(Decimal)
     for account in account_data_list:
-        commodity = account.commodity.meta["name"]
+        commodity = account.commodity.meta.get("name", account.commodity.currency)
         currency = account.currency
         market_value = get_market_value_of_inventory(pricer, target_currency, account.balance, end_date)
         market_values[(currency, commodity)] += market_value

--- a/src/fava_portfolio_returns/core/portfolio.py
+++ b/src/fava_portfolio_returns/core/portfolio.py
@@ -134,7 +134,9 @@ def group_investments(config, account_data_map: dict[str, AccountData]):
     for account in account_data_map.values():
         if account.currency not in currencies:
             currencies[account.currency] = InvestmentCurrency(
-                id=f"c:{account.currency}", currency=account.currency, name=account.commodity.meta["name"]
+                id=f"c:{account.currency}",
+                currency=account.currency,
+                name=account.commodity.meta.get("name", account.commodity.currency),
             )
     currencies_list = sorted(currencies.values(), key=lambda x: x.id)
 


### PR DESCRIPTION
It seems that the new version expects name always be present in the commodity metadata and throws an unhandled error if it's not. 
This will use commodity string itself as a backup (probably it wouldn't break anything?)
The new version looks amazing, by the way, thanks! 