### PR TITLE
Fix: cap end date at today for portfolio returns calculation

### DIFF
--- a/src/fava_portfolio_returns/__init__.py
+++ b/src/fava_portfolio_returns/__init__.py
@@ -281,6 +281,7 @@ def get_ledger_duration(entries: list[Directive]):
             break
     if not date_first or not date_last:
         raise FavaAPIError("no transaction found")
+    date_last = min(date_last, date.today())
     return (date_first, date_last)
 
 


### PR DESCRIPTION
When determining the ledger duration for portfolio returns, ensure the end date (date_last) does not exceed the current date. This prevents calculation periods from incorrectly extending into the future.

Common scenarios where future-dated entries may appear:

- Depreciation and amortization entries with future dates
- Pre-recorded credit card or loan repayment transactions
- Other advance-booked financial entries