### PR TITLE
fix: Add zero guard in MDM calculation

### DIFF
--- a/tools/vendoring/patches/beangrow_mdm_zero_division.patch
+++ b/tools/vendoring/patches/beangrow_mdm_zero_division.patch
@@ -1,0 +1,12 @@
+diff --git a/src/fava_portfolio_returns/_vendor/beangrow/returns.py b/src/fava_portfolio_returns/_vendor/beangrow/returns.py
+--- a/src/fava_portfolio_returns/_vendor/beangrow/returns.py
++++ b/src/fava_portfolio_returns/_vendor/beangrow/returns.py
+@@ -163,6 +163,8 @@ def compute_dietz_return(
+     #   start of the period.
+          pnl = end_value + start_value - np.sum(cash_flows)
+               average_capital = -start_value + weight_sum
+               +    if average_capital == 0:
+               +        return 0.0
+                    dietz = pnl / average_capital
+                         logging.debug("Start date: %s", start_date)
+                              logging.debug("End date: %s", end_date)


### PR DESCRIPTION
Fixes #135

## Summary

Adds a zero guard in the Modified Dietz Method calculation to prevent divide-by-zero errors when `average_capital` is zero.

## Problem

The Investments tab returns a 500 error for investments with short history (<3 months). When calculating returns for periods before an investment existed:
- `start_value = 0`, `weight_sum = 0`
- `average_capital = -0 + 0 = 0`
- Division by zero produces infinity, causing JSON serialization to fail

## Solution

Add a guard before the division in `returns.py`:
```python
if average_capital == 0:
    return 0.0
```

This follows the same pattern as the existing guard at lines 156-157.