### PR TITLE
fix: ensure transaction details are safely accessed in cash_flows_table

### DIFF
--- a/src/fava_portfolio_returns/api/cash_flows.py
+++ b/src/fava_portfolio_returns/api/cash_flows.py
@@ -57,7 +57,7 @@ def cash_flows_table(p: FilteredPortfolio, start_date: datetime.date, end_date: 
             "source": flow.source,
             "account": flow.account,
             "transaction": f"{flow.transaction.payee or ''} {flow.transaction.narration or ''}".strip()
-            if flow.transaction
+            if hasattr(flow, 'transaction') and flow.transaction
             else "",
         }
         for flow in cash_flows


### PR DESCRIPTION
**Description:**

When viewing the "Cash Flows" page, the following error occurs with certain versions of beangrow:

```
AttributeError: 'CashFlow' object has no attribute 'transaction'
```

**Environment:**
beancount 2.3.6
fava 1.30.8
beangrow 1.0.1