### PR TITLE
fix: Compute period-change unrealized P&L

### DIFF
--- a/src/fava_portfolio_returns/api/investments.py
+++ b/src/fava_portfolio_returns/api/investments.py
@@ -1,11 +1,10 @@
 import datetime
 import logging
-import math
 from decimal import Decimal
 
-import numpy as np
 from beancount.core import convert
 
+from fava_portfolio_returns.core.intervals import ONE_DAY
 from fava_portfolio_returns.core.portfolio import FilteredPortfolio
 from fava_portfolio_returns.core.portfolio import Portfolio
 from fava_portfolio_returns.core.utils import cost_value_of_inv
@@ -18,37 +17,32 @@ from fava_portfolio_returns.returns.twr import TWR
 logger = logging.getLogger(__name__)
 
 
-def _sanitize_float(value):
-    """Replace inf/nan with None so the value is JSON-serializable."""
-    if isinstance(value, (float, np.floating)):
-        if math.isinf(value) or math.isnan(value):
-            return None
-    return value
-
-
 def group_stats(p: FilteredPortfolio, start_date: datetime.date, end_date: datetime.date):
+    # compute unrealized P/L at start_date
+    balance_start = p.balance_at(start_date - ONE_DAY)
+    cost_value_start = cost_value_of_inv(p.pricer, p.target_currency, balance_start)
+    market_value_start = market_value_of_inv(p.pricer, p.target_currency, balance_start, start_date - ONE_DAY)
+    unrealized_pnl_start = market_value_start - cost_value_start
+
+    # compute portfolio stats at end_date
     balance = p.balance_at(end_date)
     cost_value = cost_value_of_inv(p.pricer, p.target_currency, balance)
+    # calculate market value with positions held at cost
+    # this will convert for example CORP -> USD (cost currency) -> EUR (target currency)
     market_value = market_value_of_inv(p.pricer, p.target_currency, balance, end_date)
-    # reduce to units (i.e. removing cost attribute) after calculating market value, because convert.get_value() only works with positions held at cost
-    # this will convert for example CORP -> USD (cost currency) -> EUR (target currency), instead of CORP -> EUR.
+    # reduce to units (i.e. removing cost attribute) after calculating market value
     # see https://github.com/andreasgerstmayr/fava-portfolio-returns/issues/53
-    units = balance.reduce(convert.get_units)  # sums 1 CORP {} + 2 CORP {} => 3 CORP
+    # sums 1 CORP {} + 2 CORP {} => 3 CORP
+    units = balance.reduce(convert.get_units)
+    unrealized_pnl_end = market_value - cost_value
 
     total_pnl = Decimal(MonetaryReturns().single(p, start_date, end_date))
-    # Period-bounded unrealized P&L: change in unrealized gains during the period
-    # Use start_date - 1 day to align with MonetaryReturns' convention
-    one_day = datetime.timedelta(days=1)
-    unrealized_pnl_end = market_value - cost_value
-    start_balance = p.balance_at(start_date - one_day)
-    start_cost_value = cost_value_of_inv(p.pricer, p.target_currency, start_balance)
-    start_market_value = market_value_of_inv(p.pricer, p.target_currency, start_balance, start_date - one_day)
-    unrealized_pnl_start = start_market_value - start_cost_value
     unrealized_pnl = unrealized_pnl_end - unrealized_pnl_start
     realized_pnl = total_pnl - unrealized_pnl
-    irr = _sanitize_float(IRR().single(p, start_date, end_date))
-    mdm = _sanitize_float(ModifiedDietzMethod().single(p, start_date, end_date))
-    twr = _sanitize_float(TWR().single(p, start_date, end_date))
+    irr = IRR().single(p, start_date, end_date)
+    mdm = ModifiedDietzMethod().single(p, start_date, end_date)
+    twr = TWR().single(p, start_date, end_date)
+
     return {
         "units": [pos.units for pos in units],
         "costValue": cost_value,

--- a/src/fava_portfolio_returns/api/investments_test.py
+++ b/src/fava_portfolio_returns/api/investments_test.py
@@ -44,6 +44,13 @@ class TestInvestments(unittest.TestCase):
             "twr": 1.0,
         }
 
+    def test_group_stats_unrealized_partial_timeframe(self):
+        p = load_portfolio_file("linear_growth_stock")
+        stats = group_stats(p, datetime.date(2020, 3, 1), datetime.date(2020, 6, 1))
+        assert stats["totalPnl"] == D("30")
+        assert stats["unrealizedPnl"] == D("30")
+        assert stats["realizedPnl"] == D("0")
+
     def test_group_stats_target_currency(self):
         # in USD
         p = load_portfolio_file("target_currency", target_currency="USD")


### PR DESCRIPTION
  ## Summary
  - Compute unrealized P&L as the change over the selected period (start vs end).
  - Keep realized P&L consistent with period-based total P&L.
  - Sanitize IRR/MDM/TWR when they are NaN/inf to keep API output JSON-serializable.

  ## Rationale
`MonetaryReturns().single()` currently computes total P&L over a period by comparing values just before `start_date` to values at `end_date`. To keep realized/unrealized attribution consistent with that period, unrealized P&L should  also be measured as the change in unrealized gains during the same window (end unrealized minus start unrealized). Otherwise, using end-date unrealized includes pre-start gains/losses and makes `realizedPnl = totalPnl - unrealizedPnl` inconsistent for a period view.

For example, the previous calculation could produce negative realized P&L because total P&L is period‑based, while unrealized P&L was end‑date (lifetime) and could include gains from years before the selected window.

Additionally, IRR/MDM/TWR can produce NaN/inf in edge cases; converting those to `None` avoids breaking JSON responses and UI consumers.