### PR TITLE
fix: require two cashflows for IRR calculation

### DIFF
--- a/src/fava_portfolio_returns/_vendor/beangrow/returns.py
+++ b/src/fava_portfolio_returns/_vendor/beangrow/returns.py
@@ -188,6 +188,10 @@ def compute_irr(
 ) -> float:
     """Compute the irregularly spaced IRR."""
 
+    # Require at least two cash flows (incoming + outgoing) to compute IRR.
+    if len(dated_flows) < 2:
+        return 0.0
+
     # Array of cash flows, converted to target currency.
     usd_flows = []
     for flow in dated_flows:

--- a/src/fava_portfolio_returns/metrics/irr_test.py
+++ b/src/fava_portfolio_returns/metrics/irr_test.py
@@ -80,3 +80,22 @@ plugin "beancount.plugins.implicit_prices"
         # IRR: 107.50 USD invested for 1 year = 150 USD
         # 107.5*(1+x)^(365/365) = 150
         assert IRR().single(p, datetime.date(2020, 1, 1), datetime.date(2020, 12, 31)) == approx3(0.395)
+
+    def test_no_cash_flows(self):
+        p = load_portfolio_str(
+            """
+plugin "beancount.plugins.auto_accounts"
+plugin "beancount.plugins.implicit_prices"
+
+2020-01-01 commodity CORP
+
+2020-01-01 * "Transfer in"
+  Assets:CORP                                10 CORP {10 USD}
+  Equity:Opening-Balances
+
+2020-06-01 price CORP 15 USD
+            """,
+            BEANGROW_CONFIG_CORP,
+        )
+        result = IRR().single(p, datetime.date(2020, 1, 1), datetime.date(2020, 6, 1))
+        assert result == 0

--- a/tools/vendoring/patches/beangrow_irr_require_2_cashflows.patch
+++ b/tools/vendoring/patches/beangrow_irr_require_2_cashflows.patch
@@ -1,0 +1,15 @@
+diff --git a/src/fava_portfolio_returns/_vendor/beangrow/returns.py b/src/fava_portfolio_returns/_vendor/beangrow/returns.py
+index 85766ee..7649f62 100644
+--- a/src/fava_portfolio_returns/_vendor/beangrow/returns.py
++++ b/src/fava_portfolio_returns/_vendor/beangrow/returns.py
+@@ -188,6 +188,10 @@ def compute_irr(
+ ) -> float:
+     """Compute the irregularly spaced IRR."""
+ 
++    # Require at least two cash flows (incoming + outgoing) to compute IRR.
++    if len(dated_flows) < 2:
++        return 0.0
++
+     # Array of cash flows, converted to target currency.
+     usd_flows = []
+     for flow in dated_flows:


### PR DESCRIPTION
Fix edge case where less than two cash flows are present for IRR calculation, see https://github.com/andreasgerstmayr/fava-portfolio-returns/pull/148#issuecomment-3864323216 for details