### PR TITLE
fix: filter non-investment commodities from investments tab

### DIFF
--- a/src/fava_portfolio_returns/api/investments.py
+++ b/src/fava_portfolio_returns/api/investments.py
@@ -75,6 +75,8 @@ def investments_group_by_currency(
     p: Portfolio, target_currency: str, start_date: datetime.date, end_date: datetime.date
 ):
     for currency in p.investments_config.currencies:
+        if not currency.isInvestment:
+            continue
         logger.debug("calculating stats for %s", currency.name)
         fp = p.filter([currency.id], target_currency)
         yield {

--- a/src/fava_portfolio_returns/core/portfolio.py
+++ b/src/fava_portfolio_returns/core/portfolio.py
@@ -239,10 +239,9 @@ def build_investments_config(beangrow_cfg: Any, account_data_map: dict[str, Acco
             id=f"c_{c.currency}",
             name=c.meta.get("name", c.currency),
             currency=c.currency,
-            isInvestment=True,
+            isInvestment=c.currency in investment_currencies,
         )
         for c in commodities
-        if c.currency in investment_currencies
     ]
 
     return InvestmentsConfig(accounts=accounts, groups=groups, currencies=currencies)

--- a/src/fava_portfolio_returns/core/portfolio.py
+++ b/src/fava_portfolio_returns/core/portfolio.py
@@ -239,9 +239,10 @@ def build_investments_config(beangrow_cfg: Any, account_data_map: dict[str, Acco
             id=f"c_{c.currency}",
             name=c.meta.get("name", c.currency),
             currency=c.currency,
-            isInvestment=c.currency in investment_currencies,
+            isInvestment=True,
         )
         for c in commodities
+        if c.currency in investment_currencies
     ]
 
     return InvestmentsConfig(accounts=accounts, groups=groups, currencies=currencies)


### PR DESCRIPTION
## Summary

- The `currencies` list in `build_investments_config()` included **all** commodities from the ledger (cash currencies, inventory items, private equity, etc.), causing the investments tab to display non-investment commodities.
- Filter the list to only include commodities that are actually configured as investments in the beangrow config.
- Since all remaining entries after filtering are investments, `isInvestment` is set to `True` unconditionally.

## Problem

When a ledger contains many commodity declarations beyond investments (e.g. EUR, USD, beer tracking commodities, illiquid private equity), they all appeared in the investments tab currency grouping view — even though they were not configured in `beangrow.pbtxt`.

## Test plan

- [ ] Verify investments tab only shows commodities configured in `beangrow.pbtxt`
- [ ] Verify currency grouping view no longer includes non-investment commodities
- [ ] Verify filtering by currency still works for configured investments

🤖 Generated with [Claude Code](https://claude.com/claude-code)